### PR TITLE
Add parser tests for consolidated repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,7 +159,6 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 
-*test*
 *minions*edl*
 *dev.py
 *old.py

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ Python script to normalize the data contained in the file published by Binary Ed
 This repository also contains the Docker wrappers that were previously maintained
 in separate repositories.
 
+The standalone `minionsparser.py` script is the source of truth. Both Docker
+images copy that local script at build time, so parser fixes only need to land in
+one place.
+
 ## Alpine cron container
 
 The Alpine image installs the parser into the daily cron directory and keeps cron
@@ -52,6 +56,20 @@ docker/python-once/build-image.sh
 
 Both images write output to `/tmp/minionsparser` inside the container. The build
 scripts bind mount `/tmp/minionsparser` from the host.
+
+# Development
+
+Run the unit tests with:
+
+```sh
+python3 -m unittest discover -s tests
+```
+
+When changing parser behavior, update `minionsparser.py` first and keep the
+Docker wrappers as thin runtime variants:
+
+- `docker/alpine-cron/` builds the scheduled Alpine container.
+- `docker/python-once/` builds the run-once Python container.
 
 # Support Policy
 

--- a/minionsparser.py
+++ b/minionsparser.py
@@ -16,8 +16,8 @@ FEEDS = {
 }
 
 
-def fetch_scanners(url):
-    with urlopen(url, timeout=REQUEST_TIMEOUT_SECONDS) as response:
+def fetch_scanners(url, opener=urlopen):
+    with opener(url, timeout=REQUEST_TIMEOUT_SECONDS) as response:
         payload = json.load(response)
 
     scanners = payload.get("scanners")
@@ -27,21 +27,29 @@ def fetch_scanners(url):
     return scanners
 
 
-def write_edl(url, filename):
-    output_path = OUTPUT_DIR / filename
-    scanners = sorted(set(fetch_scanners(url)), reverse=True)
+def normalize_scanners(scanners):
+    return sorted(set(scanners), reverse=True)
+
+
+def write_edl(url, filename, output_dir=OUTPUT_DIR, opener=urlopen):
+    output_path = output_dir / filename
+    scanners = normalize_scanners(fetch_scanners(url, opener=opener))
     output_path.write_text("\n".join(scanners) + "\n", encoding="utf-8")
     print(f"Wrote {len(scanners)} entries to {output_path}")
 
 
-def main():
-    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+def process_feeds(feeds=FEEDS, output_dir=OUTPUT_DIR, opener=urlopen):
+    output_dir.mkdir(parents=True, exist_ok=True)
 
-    for url, filename in FEEDS.items():
-        try:
-            write_edl(url, filename)
-        except (HTTPError, URLError, TimeoutError, ValueError, json.JSONDecodeError) as error:
-            raise SystemExit(f"Failed to process {url}: {error}") from error
+    for url, filename in feeds.items():
+        write_edl(url, filename, output_dir=output_dir, opener=opener)
+
+
+def main():
+    try:
+        process_feeds()
+    except (HTTPError, URLError, TimeoutError, ValueError, json.JSONDecodeError) as error:
+        raise SystemExit(f"Failed to process feeds: {error}") from error
 
 
 if __name__ == "__main__":

--- a/tests/test_minionsparser.py
+++ b/tests/test_minionsparser.py
@@ -1,0 +1,79 @@
+import importlib.util
+import io
+import json
+import unittest
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = PROJECT_ROOT / "minionsparser.py"
+
+
+def load_parser_module():
+    spec = importlib.util.spec_from_file_location("minionsparser", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeResponse(io.StringIO):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return False
+
+
+class MinionsParserTest(unittest.TestCase):
+    def setUp(self):
+        self.parser = load_parser_module()
+
+    def test_normalize_scanners_deduplicates_and_sorts_descending(self):
+        scanners = ["192.0.2.1", "198.51.100.2", "192.0.2.1"]
+
+        self.assertEqual(
+            self.parser.normalize_scanners(scanners),
+            ["198.51.100.2", "192.0.2.1"],
+        )
+
+    def test_process_feeds_writes_each_edl_file(self):
+        feeds = {
+            "https://example.invalid/minions": "minions-v4.edl.txt",
+            "https://example.invalid/minions-ipv6": "minions-v6.edl.txt",
+        }
+        payloads = {
+            "https://example.invalid/minions": {"scanners": ["192.0.2.1", "198.51.100.2"]},
+            "https://example.invalid/minions-ipv6": {"scanners": ["2001:db8::2", "2001:db8::1"]},
+        }
+
+        def opener(url, timeout):
+            self.assertEqual(timeout, self.parser.REQUEST_TIMEOUT_SECONDS)
+            return FakeResponse(json.dumps(payloads[url]))
+
+        output_dir = PROJECT_ROOT / ".test-output"
+        try:
+            self.parser.process_feeds(feeds=feeds, output_dir=output_dir, opener=opener)
+
+            self.assertEqual(
+                (output_dir / "minions-v4.edl.txt").read_text(encoding="utf-8"),
+                "198.51.100.2\n192.0.2.1\n",
+            )
+            self.assertEqual(
+                (output_dir / "minions-v6.edl.txt").read_text(encoding="utf-8"),
+                "2001:db8::2\n2001:db8::1\n",
+            )
+        finally:
+            for path in output_dir.glob("*"):
+                path.unlink()
+            output_dir.rmdir()
+
+    def test_fetch_scanners_rejects_missing_scanner_list(self):
+        def opener(url, timeout):
+            return FakeResponse(json.dumps({"not_scanners": []}))
+
+        with self.assertRaisesRegex(ValueError, "scanners list"):
+            self.parser.fetch_scanners("https://example.invalid/minions", opener=opener)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Make parser feed fetching and normalization testable
- Add unit tests for normalization, file output, and invalid feed responses
- Document the consolidated repo layout and Docker wrapper roles
- Allow tests to be tracked by removing the broad *test* ignore rule

## Tests
- python3 -m unittest discover -s tests